### PR TITLE
fix: use package ranges instead of specifying versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.2.8",
       "license": "MIT",
       "dependencies": {
-        "remix-auth": "3.4.0",
-        "remix-auth-oauth2": "1.5.0"
+        "remix-auth-oauth2": "^1.5.0"
       },
       "devDependencies": {
         "@babel/core": "7.20.12",
@@ -33,13 +32,15 @@
         "eslint-plugin-unicorn": "45.0.2",
         "prettier": "2.8.1",
         "react": "18.2.0",
+        "remix-auth": "3.4.0",
         "semantic-release": "19.0.5",
         "ts-node": "10.9.1",
         "typescript": "4.9.4",
         "vitest": "0.26.3"
       },
       "peerDependencies": {
-        "@remix-run/server-runtime": "1.9.0"
+        "@remix-run/server-runtime": "1.9.0",
+        "remix-auth": ">=3.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@remix-run/server-runtime": "1.9.0"
+    "@remix-run/server-runtime": ">=1.1.0",
+    "remix-auth": ">=3.2.2"
   },
   "devDependencies": {
     "@babel/core": "7.20.12",
@@ -55,14 +56,14 @@
     "eslint-plugin-unicorn": "45.0.2",
     "prettier": "2.8.1",
     "react": "18.2.0",
+    "remix-auth": "3.4.0",
     "semantic-release": "19.0.5",
     "ts-node": "10.9.1",
     "typescript": "4.9.4",
     "vitest": "0.26.3"
   },
   "dependencies": {
-    "remix-auth": "3.4.0",
-    "remix-auth-oauth2": "1.5.0"
+    "remix-auth-oauth2": "^1.5.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
This undos the exact version change pushed in #282

- remix-auth is moved to `peerDependencies` as the documentation for remix-auth-spotify specifies that it should be manually installed.
- remix-auth is added to `devDependencies` for any tests that rely on remix have access to them.
- remix-auth-oauth2 is made into a package range that will support all 1.x.x releases >= 1.5.0.

This change was made because installing as specifed in the documentation lead to multiple versions of remix being installed which does not work with any typescript type overloading that you might do.

https://github.com/remix-run/remix/pull/1876

For example, I have an existing remix app using remix@1.7.4 with the following in my remix.env.d.ts:

```typescript
// in remix.env.d.ts
import '@remix-run/server-runtime'

declare module '@remix-run/server-runtime' {
  interface AppLoadContext {
    requestId: string
  }
}
```

This allows me to access the `requestId` in a `loader` like so:

```typescript
import { LoaderArgs } from '@remix-run/node'

export async function loader({ context }: LoaderArgs) {
  foobar(context.requestId)
}
```

Installing remix-auth-spotify as specified in the docs caused remix@1.9.0 to be installed alongside 1.7.4. This caused the type overriding in Typescript to not work at all and make `context.requestId` become unknown. This was resolved by bumping up remix to 1.9.0 in my package.json. By using package ranges, downstream consumers of this package are able to define the versions of remix.

Question: If accepted, would it make sense to also have remix-auth-oauth2 moved to `peerDependencies`? I could envision an authentication situation where the upstream consumer of this package has Spotify auth AND a custom OAuth2 setup. I don't have a super strong stance, though.